### PR TITLE
Add LicenseFinder and list of permissible licenses

### DIFF
--- a/.github/workflows/licensing.yml
+++ b/.github/workflows/licensing.yml
@@ -1,0 +1,22 @@
+name: Verify dependency licenses
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  licensing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: sudo gem install license_finder
+      - run: composer install
+      - run: license_finder

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,0 +1,25 @@
+---
+- - :permit
+  - MIT
+  - :who:
+    :why:
+    :versions: []
+    :when: 2022-02-17 23:55:53.997649000 Z
+- - :permit
+  - apache-2.0
+  - :who:
+    :why:
+    :versions: []
+    :when: 2022-02-17 23:55:56.945685000 Z
+- - :permit
+  - bsd-3-clause
+  - :who:
+    :why:
+    :versions: []
+    :when: 2022-02-17 23:56:11.780536000 Z
+- - :permit
+  - bsd-2-clause
+  - :who:
+    :why:
+    :versions: []
+    :when: 2022-02-17 23:56:13.798327000 Z


### PR DESCRIPTION
This adds LicenseFinder in an action and runs it (along with `composer`) to check the dependency licenses. 